### PR TITLE
Ignored type hint requirement for this old library.

### DIFF
--- a/rules-engine/src/rules_engine/parser.py
+++ b/rules-engine/src/rules_engine/parser.py
@@ -8,7 +8,7 @@ import re
 from datetime import datetime, timedelta
 from enum import StrEnum
 
-from greenbutton_objects import parse
+from greenbutton_objects import parse # type: ignore
 
 from .pydantic_models import (
     ElectricBillingInput,


### PR DESCRIPTION
MyPy throws a type error because greenbutton_objects lacks type hints.  I am ignoring this error for now because it does not affect performance.